### PR TITLE
Add workflow for handling push event details

### DIFF
--- a/.github/workflows/workflow-events.yml
+++ b/.github/workflows/workflow-events.yml
@@ -1,0 +1,23 @@
+name: 02 Workflow Events
+
+on: push
+
+jobs:
+  echo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Event name
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+      - name: Event path
+        run: |
+          echo "Event path: ${{ github.event_path }}"
+      - name: Event payload
+        run: |
+          echo "Event payload: ${{ toJson(github.event) }}"
+      - name: Event actor
+        run: |
+          echo "Event actor: ${{ github.actor }}"
+      - name: Event repository
+        run: |
+          echo "Event repository: ${{ github.repository }}"


### PR DESCRIPTION
This branch adds a new GitHub Actions workflow file, .github/workflows/workflow-events.yml, named "02 Workflow Events". The workflow is triggered on push and contains a single job that echoes various GitHub event context values, including the event name, event path, event payload (as JSON), event actor, and event repository. This demonstrates how to access and display event-related information within a workflow.